### PR TITLE
Fks-1219

### DIFF
--- a/app/components/assignment/AssignedRolesTable.tsx
+++ b/app/components/assignment/AssignedRolesTable.tsx
@@ -1,4 +1,4 @@
-import { Button, Heading, Link, Table, VStack } from '@navikt/ds-react';
+import { Button, Link, Table, VStack } from '@navikt/ds-react';
 import type { IAssignedRoles } from '~/data/types/userTypes';
 import React from 'react';
 import { Outlet, useLoaderData, useParams, useSearchParams } from '@remix-run/react';

--- a/app/components/assignment/NewAssignmentRoleTable.tsx
+++ b/app/components/assignment/NewAssignmentRoleTable.tsx
@@ -14,7 +14,7 @@ interface AssignRoleTableProps {
     isAssignedRoles: IRole[];
     size: number;
     resourceId: string | undefined;
-    totalPages: number;
+    totalPages?: number;
     currentPage: number;
     basePath?: string;
 }

--- a/app/components/assignment/NewAssignmentUserTable.tsx
+++ b/app/components/assignment/NewAssignmentUserTable.tsx
@@ -13,7 +13,7 @@ interface AssignUserTableProps {
     isAssignedUsers: IUserItem[];
     size: string;
     resourceId: string | undefined;
-    totalPages: number;
+    totalPages?: number;
     currentPage: number;
     basePath?: string;
 }

--- a/app/components/common/Buttons/SecondaryAddNewLinkButton.tsx
+++ b/app/components/common/Buttons/SecondaryAddNewLinkButton.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@navikt/ds-react';
+import { PlusIcon } from '@navikt/aksel-icons';
+import React from 'react';
+
+export const SecondaryAddNewLinkButton = ({
+    id,
+    label,
+    handleOnClick,
+}: {
+    id?: string;
+    label: string;
+    handleOnClick: () => void;
+}) => {
+    return (
+        <Button
+            id={id}
+            role="link"
+            className={'no-underline-button'}
+            variant={'secondary'}
+            iconPosition="right"
+            icon={<PlusIcon aria-hidden />}
+            onClick={handleOnClick}>
+            {label}
+        </Button>
+    );
+};

--- a/app/components/common/Table/Header/TableHeader.tsx
+++ b/app/components/common/Table/Header/TableHeader.tsx
@@ -1,4 +1,4 @@
-import { Heading, VStack } from '@navikt/ds-react';
+import { Heading, HStack, VStack } from '@navikt/ds-react';
 import React from 'react';
 
 interface TableHeaderProps {
@@ -6,6 +6,8 @@ interface TableHeaderProps {
     titleAlignment?: 'center' | 'end' | 'start' | undefined;
     subTitle?: string;
     isSubHeader?: boolean;
+    HeaderButton?: React.ReactElement;
+    spacing?: boolean;
 }
 
 export const TableHeader = ({
@@ -13,16 +15,21 @@ export const TableHeader = ({
     titleAlignment = 'start',
     subTitle,
     isSubHeader,
+    HeaderButton,
+    spacing,
 }: TableHeaderProps) => {
     return (
-        <VStack>
-            <Heading
-                level={isSubHeader ? '2' : '1'}
-                size="xlarge"
-                align={titleAlignment}
-                spacing={!subTitle}>
-                {title}
-            </Heading>
+        <VStack width={'100%'}>
+            <HStack justify={'space-between'} align={'center'}>
+                <Heading
+                    level={isSubHeader ? '2' : '1'}
+                    size={isSubHeader ? 'large' : 'xlarge'}
+                    align={titleAlignment}
+                    spacing={spacing}>
+                    {title}
+                </Heading>
+                {HeaderButton && HeaderButton}
+            </HStack>
             {subTitle && (
                 <Heading level={isSubHeader ? '3' : '2'} size="small">
                     {subTitle}

--- a/app/components/common/Table/Header/TableHeaderLayout.tsx
+++ b/app/components/common/Table/Header/TableHeaderLayout.tsx
@@ -40,7 +40,7 @@ export const TableHeaderLayout = ({
                 isSubHeader={isSubHeader}
             />
             {alertMessage && (
-                <Box asChild>
+                <Box asChild marginBlock={'4'}>
                     <Alert variant={alertMessage.variant} size={'small'} contentMaxWidth={false}>
                         {alertMessage.heading && (
                             <Heading size={'xsmall'}>{alertMessage.heading}</Heading>

--- a/app/components/org-unit-selector/OrgUnitTreeSelector.tsx
+++ b/app/components/org-unit-selector/OrgUnitTreeSelector.tsx
@@ -157,7 +157,9 @@ const OrgUnitTreeSelector = ({
                 }
 
                 return (
-                    <Accordion key={node.organisationUnitId + index}>{renderTree(node)}</Accordion>
+                    <Accordion size={'small'} key={node.organisationUnitId + index}>
+                        {renderTree(node)}
+                    </Accordion>
                 );
             })}
         </>

--- a/app/components/resource-module-admin/opprettTildeling/ChooseAccessRole.tsx
+++ b/app/components/resource-module-admin/opprettTildeling/ChooseAccessRole.tsx
@@ -9,7 +9,7 @@ interface ChooseAccessRoleProps {
 
 const ChooseAccessRole = ({ accessRoles, setNewAccessRole }: ChooseAccessRoleProps) => {
     return (
-        <RadioGroup legend={'Velg aksessrolle'} onChange={setNewAccessRole}>
+        <RadioGroup legend={'Velg aksessrolle'} onChange={setNewAccessRole} size={'small'}>
             <VStack>
                 {sortAndCapitalizeRoles(accessRoles).map((accessRole, index) => (
                     <Radio key={accessRole.accessRoleId} value={accessRole.accessRoleId}>

--- a/app/components/resource-module-admin/opprettTildeling/SummaryOfTildeling.tsx
+++ b/app/components/resource-module-admin/opprettTildeling/SummaryOfTildeling.tsx
@@ -1,18 +1,13 @@
 import { IResourceModuleAssignment } from '~/data/types/resourceTypes';
-import { Alert, FormSummary, List } from '@navikt/ds-react';
+import { ErrorMessage, FormSummary, List } from '@navikt/ds-react';
 import { IAccessRole } from '~/data/types/userTypes';
 
 interface SummaryOfTildelingProps {
     assignment: IResourceModuleAssignment;
-    missingFields: boolean;
     accessRoles: IAccessRole[];
 }
 
-const SummaryOfTildeling = ({
-    assignment,
-    missingFields,
-    accessRoles,
-}: SummaryOfTildelingProps) => {
+const SummaryOfTildeling = ({ assignment, accessRoles }: SummaryOfTildelingProps) => {
     const findAccessRoleById = (id: string): string => {
         const foundRole: string | undefined = accessRoles.find(
             (role) => role.accessRoleId === id
@@ -28,25 +23,30 @@ const SummaryOfTildeling = ({
                 </FormSummary.Header>
 
                 <FormSummary.Answers>
-                    {assignment.user?.firstName && (
-                        <FormSummary.Answer>
-                            <FormSummary.Label>Valgt bruker</FormSummary.Label>
-                            <FormSummary.Value>
-                                {assignment.user?.firstName + ' ' + assignment.user?.lastName}
-                            </FormSummary.Value>
-                        </FormSummary.Answer>
-                    )}
-                    {assignment.accessRoleId && (
-                        <FormSummary.Answer>
-                            <FormSummary.Label>Valgt aksessrolle</FormSummary.Label>
-                            <FormSummary.Value>
-                                {findAccessRoleById(assignment.accessRoleId)}
-                            </FormSummary.Value>
-                        </FormSummary.Answer>
-                    )}
+                    <FormSummary.Answer>
+                        <FormSummary.Label>Valgt bruker</FormSummary.Label>
+                        <FormSummary.Value>
+                            {!assignment.user ? (
+                                <ErrorMessage size="small">Ingen bruker valgt</ErrorMessage>
+                            ) : (
+                                assignment.user?.firstName + ' ' + assignment.user?.lastName
+                            )}
+                        </FormSummary.Value>
+                    </FormSummary.Answer>
 
-                    {assignment.orgUnits.length > 0 &&
-                        (assignment.includeSubOrgUnits ? (
+                    <FormSummary.Answer>
+                        <FormSummary.Label>Valgt aksessrolle</FormSummary.Label>
+                        <FormSummary.Value>
+                            {!assignment.accessRoleId ? (
+                                <ErrorMessage size="small">Ingen aksessrolle valgt</ErrorMessage>
+                            ) : (
+                                findAccessRoleById(assignment.accessRoleId)
+                            )}
+                        </FormSummary.Value>
+                    </FormSummary.Answer>
+
+                    {assignment.orgUnits.length > 0 ? (
+                        assignment.includeSubOrgUnits ? (
                             <FormSummary.Answer>
                                 <FormSummary.Label>
                                     Inkluderte org.enheter - da MED tilhørende underenheter
@@ -70,19 +70,17 @@ const SummaryOfTildeling = ({
                                     </List>
                                 </FormSummary.Value>
                             </FormSummary.Answer>
-                        ))}
+                        )
+                    ) : (
+                        <FormSummary.Answer>
+                            <FormSummary.Label>Valgte org.enheter</FormSummary.Label>
+                            <FormSummary.Value>
+                                <ErrorMessage size="small">Ingen org.enheter valgt</ErrorMessage>
+                            </FormSummary.Value>
+                        </FormSummary.Answer>
+                    )}
                 </FormSummary.Answers>
             </FormSummary>
-
-            {missingFields && (
-                <Alert variant={'error'}>
-                    <ul>
-                        {!assignment.user && <li>Må ha valgt en bruker</li>}
-                        {!assignment.accessRoleId && <li>Må ha valgt en aksessrolle</li>}
-                        {assignment.orgUnits.length === 0 && <li>Må ha valgt orgenheter</li>}
-                    </ul>
-                </Alert>
-            )}
         </div>
     );
 };

--- a/app/components/resource-module-admin/opprettTildeling/TildelUserSearchResultList.tsx
+++ b/app/components/resource-module-admin/opprettTildeling/TildelUserSearchResultList.tsx
@@ -35,42 +35,61 @@ const TildelUserSearchResultList = ({
                     {usersPage.totalItems === 0 && (
                         <BodyShort>Ingen resultater i listen...</BodyShort>
                     )}
-                    {usersPage.users?.map((user) => (
-                        <Table.Row
-                            key={user.userName}
-                            selected={newAssignment.user?.resourceId === user.resourceId}>
-                            <Table.HeaderCell>
-                                {`${user.firstName} ${user.lastName}`}
-                            </Table.HeaderCell>
-                            <Table.DataCell>
-                                {user.roles?.map((role) => role.roleName).join(', ')}
-                            </Table.DataCell>
-                            <Table.DataCell align={'right'}>
-                                {newAssignment.user?.resourceId === user.resourceId ? (
-                                    <Button
-                                        className={'nowrap'}
-                                        icon={<CheckmarkCircleIcon />}
-                                        variant={'secondary'}
-                                        onClick={() => handleSelectUser(user)}>
-                                        Valgt
-                                    </Button>
-                                ) : (
+                    {!newAssignment.user?.resourceId &&
+                        usersPage.users?.map((user) => (
+                            <Table.Row
+                                key={user.userName}
+                                selected={newAssignment.user?.resourceId === user.resourceId}
+                                onClick={() => handleSelectUser(user)}>
+                                <Table.HeaderCell>
+                                    {`${user.firstName} ${user.lastName}`}
+                                </Table.HeaderCell>
+                                <Table.DataCell>
+                                    {user.roles?.map((role) => role.roleName).join(', ')}
+                                </Table.DataCell>
+                                <Table.DataCell align={'right'}>
                                     <Button
                                         className={'nowrap'}
                                         onClick={() => handleSelectUser(user)}>
                                         Velg bruker
                                     </Button>
-                                )}
+                                </Table.DataCell>
+                            </Table.Row>
+                        ))}
+                    {!!newAssignment.user && (
+                        <Table.Row
+                            key={newAssignment.user.userName}
+                            onClick={() =>
+                                newAssignment.user && handleSelectUser(newAssignment.user)
+                            }>
+                            <Table.HeaderCell>
+                                {`${newAssignment.user.firstName} ${newAssignment.user.lastName}`}
+                            </Table.HeaderCell>
+                            <Table.DataCell>
+                                {newAssignment.user.roles?.map((role) => role.roleName).join(', ')}
+                            </Table.DataCell>
+                            <Table.DataCell align={'right'}>
+                                <Button
+                                    className={'nowrap'}
+                                    icon={<CheckmarkCircleIcon />}
+                                    variant={'secondary'}
+                                    onClick={() =>
+                                        newAssignment.user && handleSelectUser(newAssignment.user)
+                                    }>
+                                    Valgt
+                                </Button>
                             </Table.DataCell>
                         </Table.Row>
-                    ))}
+                    )}
                 </Table.Body>
             </Table>
-            <TablePagination
-                currentPage={usersPage.currentPage}
-                totalPages={usersPage.totalPages}
-                size={size}
-            />
+            {!newAssignment.user?.resourceId && (
+                <TablePagination
+                    currentPage={usersPage.currentPage}
+                    totalPages={usersPage.totalPages}
+                    size={size}
+                />
+            )}
         </VStack>
     );
 };

--- a/app/components/resource-module-admin/opprettTildeling/TildelUserSearchResultList.tsx
+++ b/app/components/resource-module-admin/opprettTildeling/TildelUserSearchResultList.tsx
@@ -1,63 +1,77 @@
-import { BodyShort, Button, Heading, HStack, List, VStack } from '@navikt/ds-react';
+import { BodyShort, Button, Heading, HStack, List, Table, VStack } from '@navikt/ds-react';
 import {
     IResourceModuleAssignment,
     IResourceModuleUser,
     IResourceModuleUsersPage,
 } from '~/data/types/resourceTypes';
 import { CheckmarkCircleIcon } from '@navikt/aksel-icons';
+import React from 'react';
+import { TablePagination } from '~/components/common/Table/TablePagination';
 
 interface TildelUserSearchResultListProps {
     newAssignment: IResourceModuleAssignment;
     usersPage: IResourceModuleUsersPage;
     handleSelectUser: (newUser: IResourceModuleUser) => void;
+    size?: string;
 }
 
 const TildelUserSearchResultList = ({
     newAssignment,
     usersPage,
     handleSelectUser,
+    size,
 }: TildelUserSearchResultListProps) => {
     return (
-        <List id="user-search-list">
-            {usersPage.totalItems === 0 && (
-                <li className={'list-item__space-between'}>Ingen resultater i listen...</li>
-            )}
-            {usersPage.users.map((user) => (
-                <li key={user.resourceId} className={'list-item__space-between'}>
-                    <VStack marginBlock={'4'}>
-                        <Heading level={'2'} size={'small'}>
-                            {user.firstName + ' ' + user.lastName}
-                        </Heading>
-                        {user.roles && (
-                            <BodyShort>
-                                {user.roles?.length > 0
-                                    ? user.roles.map((role, index) => (
-                                          <span key={role.roleId + index}>
-                                              {role.roleName}
-                                              {user.roles.length - 1 > index && ', '}
-                                          </span>
-                                      ))
-                                    : 'Har ingen roller'}
-                            </BodyShort>
-                        )}
-                    </VStack>
-                    {newAssignment.user?.resourceId === user.resourceId ? (
-                        <span>
-                            <Button
-                                icon={<CheckmarkCircleIcon />}
-                                variant={'secondary'}
-                                onClick={() => handleSelectUser(user)}>
-                                Valgt
-                            </Button>
-                        </span>
-                    ) : (
-                        <span>
-                            <Button onClick={() => handleSelectUser(user)}>Velg bruker</Button>
-                        </span>
+        <VStack id="user-search-list">
+            <Table>
+                <Table.Header>
+                    <Table.Row>
+                        <Table.HeaderCell scope="col">Navn</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Roller</Table.HeaderCell>
+                        <Table.HeaderCell></Table.HeaderCell>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {usersPage.totalItems === 0 && (
+                        <BodyShort>Ingen resultater i listen...</BodyShort>
                     )}
-                </li>
-            ))}
-        </List>
+                    {usersPage.users?.map((user) => (
+                        <Table.Row
+                            key={user.userName}
+                            selected={newAssignment.user?.resourceId === user.resourceId}>
+                            <Table.HeaderCell>
+                                {`${user.firstName} ${user.lastName}`}
+                            </Table.HeaderCell>
+                            <Table.DataCell>
+                                {user.roles?.map((role) => role.roleName).join(', ')}
+                            </Table.DataCell>
+                            <Table.DataCell align={'right'}>
+                                {newAssignment.user?.resourceId === user.resourceId ? (
+                                    <Button
+                                        className={'nowrap'}
+                                        icon={<CheckmarkCircleIcon />}
+                                        variant={'secondary'}
+                                        onClick={() => handleSelectUser(user)}>
+                                        Valgt
+                                    </Button>
+                                ) : (
+                                    <Button
+                                        className={'nowrap'}
+                                        onClick={() => handleSelectUser(user)}>
+                                        Velg bruker
+                                    </Button>
+                                )}
+                            </Table.DataCell>
+                        </Table.Row>
+                    ))}
+                </Table.Body>
+            </Table>
+            <TablePagination
+                currentPage={usersPage.currentPage}
+                totalPages={usersPage.totalPages}
+                size={size}
+            />
+        </VStack>
     );
 };
 

--- a/app/components/resource-module-admin/opprettTildeling/TildelUserSearchResultList.tsx
+++ b/app/components/resource-module-admin/opprettTildeling/TildelUserSearchResultList.tsx
@@ -33,7 +33,6 @@ const TildelUserSearchResultList = ({
                                 {user.roles?.length > 0
                                     ? user.roles.map((role, index) => (
                                           <span key={role.roleId + index}>
-                                              {/*@ts-ignore*/}
                                               {role.roleName}
                                               {user.roles.length - 1 > index && ', '}
                                           </span>

--- a/app/components/resource-module-admin/opprettTildeling/TildelUserSearchResultList.tsx
+++ b/app/components/resource-module-admin/opprettTildeling/TildelUserSearchResultList.tsx
@@ -1,4 +1,4 @@
-import { BodyShort, Button, Heading, HStack, List, Table, VStack } from '@navikt/ds-react';
+import { BodyShort, Button, Table, VStack } from '@navikt/ds-react';
 import {
     IResourceModuleAssignment,
     IResourceModuleUser,

--- a/app/components/resource-module-admin/opprettTildeling/TildelUsersTable.tsx
+++ b/app/components/resource-module-admin/opprettTildeling/TildelUsersTable.tsx
@@ -32,7 +32,7 @@ const TildelUsersTable = ({
         <VStack id="user-search-list">
             {!newAssignment.user && (
                 <TildelingToolbar allOrgUnits={allOrgUnits} accessRoles={accessRoles} />
-            )}{' '}
+            )}
             <Table>
                 <Table.Header>
                     <Table.Row>
@@ -48,7 +48,7 @@ const TildelUsersTable = ({
                     {!newAssignment.user?.resourceId &&
                         usersPage.users?.map((user) => (
                             <Table.Row
-                                key={user.userName}
+                                key={user.resourceId}
                                 selected={newAssignment.user?.resourceId === user.resourceId}
                                 onClick={() => handleSelectUser(user)}>
                                 <Table.HeaderCell>

--- a/app/components/resource-module-admin/opprettTildeling/TildelUsersTable.tsx
+++ b/app/components/resource-module-admin/opprettTildeling/TildelUsersTable.tsx
@@ -4,7 +4,7 @@ import {
     IResourceModuleUser,
     IResourceModuleUsersPage,
 } from '~/data/types/resourceTypes';
-import { CheckmarkCircleIcon } from '@navikt/aksel-icons';
+import { XMarkIcon } from '@navikt/aksel-icons';
 import React from 'react';
 import { TablePagination } from '~/components/common/Table/TablePagination';
 import TildelingToolbar from '~/components/resource-module-admin/opprettTildeling/TildelingToolbar';
@@ -59,6 +59,7 @@ const TildelUsersTable = ({
                                 </Table.DataCell>
                                 <Table.DataCell align={'right'}>
                                     <Button
+                                        size={'small'}
                                         className={'nowrap'}
                                         onClick={() => handleSelectUser(user)}>
                                         Velg bruker
@@ -81,12 +82,13 @@ const TildelUsersTable = ({
                             <Table.DataCell align={'right'}>
                                 <Button
                                     className={'nowrap'}
-                                    icon={<CheckmarkCircleIcon />}
-                                    variant={'secondary'}
+                                    size={'small'}
+                                    icon={<XMarkIcon />}
+                                    variant={'tertiary-neutral'}
                                     onClick={() =>
                                         newAssignment.user && handleSelectUser(newAssignment.user)
                                     }>
-                                    Valgt
+                                    Angre
                                 </Button>
                             </Table.DataCell>
                         </Table.Row>

--- a/app/components/resource-module-admin/opprettTildeling/TildelUsersTable.tsx
+++ b/app/components/resource-module-admin/opprettTildeling/TildelUsersTable.tsx
@@ -7,22 +7,32 @@ import {
 import { CheckmarkCircleIcon } from '@navikt/aksel-icons';
 import React from 'react';
 import { TablePagination } from '~/components/common/Table/TablePagination';
+import TildelingToolbar from '~/components/resource-module-admin/opprettTildeling/TildelingToolbar';
+import { IUnitItem } from '~/data/types/orgUnitTypes';
+import { IAccessRole } from '~/data/types/userTypes';
 
 interface TildelUserSearchResultListProps {
     newAssignment: IResourceModuleAssignment;
     usersPage: IResourceModuleUsersPage;
     handleSelectUser: (newUser: IResourceModuleUser) => void;
     size?: string;
+    allOrgUnits: IUnitItem[];
+    accessRoles: IAccessRole[];
 }
 
-const TildelUserSearchResultList = ({
+const TildelUsersTable = ({
     newAssignment,
     usersPage,
     handleSelectUser,
     size,
+    allOrgUnits,
+    accessRoles,
 }: TildelUserSearchResultListProps) => {
     return (
         <VStack id="user-search-list">
+            {!newAssignment.user && (
+                <TildelingToolbar allOrgUnits={allOrgUnits} accessRoles={accessRoles} />
+            )}{' '}
             <Table>
                 <Table.Header>
                     <Table.Row>
@@ -94,4 +104,4 @@ const TildelUserSearchResultList = ({
     );
 };
 
-export default TildelUserSearchResultList;
+export default TildelUsersTable;

--- a/app/components/resource-module-admin/opprettTildeling/TildelingToolbar.tsx
+++ b/app/components/resource-module-admin/opprettTildeling/TildelingToolbar.tsx
@@ -1,10 +1,11 @@
 import OrgUnitFilterModal from '~/components/org-unit-filter/OrgUnitFilterModal';
-import ResourceModuleSearch from '~/components/resource-module-admin/ResourceModuleSearch';
 import { HStack, Label, VStack } from '@navikt/ds-react';
 import ChipsFilters from '~/components/common/ChipsFilters';
 import AllAccessRolesFilter from '~/components/resource-module-admin/AllAccessRolesFilter';
 import { IUnitItem } from '~/data/types/orgUnitTypes';
 import { IAccessRole } from '~/data/types/userTypes';
+import { Search } from '~/components/common/Search';
+import React from 'react';
 
 interface TildelingToolbarProps {
     allOrgUnits: IUnitItem[];
@@ -20,7 +21,7 @@ const TildelingToolbar = ({ allOrgUnits, accessRoles }: TildelingToolbarProps) =
                     <OrgUnitFilterModal orgUnitList={allOrgUnits} />
                 </VStack>
                 <AllAccessRolesFilter roles={accessRoles} />
-                <ResourceModuleSearch />
+                <Search label="Søk etter brukere" id={'search-user-role'} />
             </HStack>
             <ChipsFilters />
         </VStack>

--- a/app/components/resource-module-admin/opprettTildeling/TildelingToolbar.tsx
+++ b/app/components/resource-module-admin/opprettTildeling/TildelingToolbar.tsx
@@ -14,9 +14,9 @@ interface TildelingToolbarProps {
 const TildelingToolbar = ({ allOrgUnits, accessRoles }: TildelingToolbarProps) => {
     return (
         <VStack gap={'2'}>
-            <HStack align={'end'} justify={'space-between'}>
+            <HStack className={'filters'} gap={'4'} justify="end" align="end">
                 <VStack gap={'2'}>
-                    <Label>Filter på brukerens tilhørighet</Label>
+                    <Label>Filter på tilhørighet</Label>
                     <OrgUnitFilterModal orgUnitList={allOrgUnits} />
                 </VStack>
                 <AllAccessRolesFilter roles={accessRoles} />

--- a/app/components/resource-module-admin/opprettTildeling/TildelingToolbar.tsx
+++ b/app/components/resource-module-admin/opprettTildeling/TildelingToolbar.tsx
@@ -14,14 +14,14 @@ interface TildelingToolbarProps {
 const TildelingToolbar = ({ allOrgUnits, accessRoles }: TildelingToolbarProps) => {
     return (
         <>
-            <HStack className={'toolbar'} align={'end'} justify={'space-between'}>
-                <div className={'org-unit-filter-with-help-text'}>
+            <HStack align={'end'} justify={'space-between'}>
+                <HStack align={'center'} gap={'2'}>
                     <OrgUnitFilterModal orgUnitList={allOrgUnits} />
                     <HelpText>
                         Dette er kun filter for brukerens tilhørighet. Må ikke forveksles med
                         org.enhetstildelingen.
                     </HelpText>
-                </div>
+                </HStack>
                 <AllAccessRolesFilter roles={accessRoles} />
                 <ResourceModuleSearch />
             </HStack>

--- a/app/components/resource-module-admin/opprettTildeling/TildelingToolbar.tsx
+++ b/app/components/resource-module-admin/opprettTildeling/TildelingToolbar.tsx
@@ -1,6 +1,6 @@
 import OrgUnitFilterModal from '~/components/org-unit-filter/OrgUnitFilterModal';
 import ResourceModuleSearch from '~/components/resource-module-admin/ResourceModuleSearch';
-import { HelpText, HStack } from '@navikt/ds-react';
+import { HStack, Label, VStack } from '@navikt/ds-react';
 import ChipsFilters from '~/components/common/ChipsFilters';
 import AllAccessRolesFilter from '~/components/resource-module-admin/AllAccessRolesFilter';
 import { IUnitItem } from '~/data/types/orgUnitTypes';
@@ -13,20 +13,17 @@ interface TildelingToolbarProps {
 
 const TildelingToolbar = ({ allOrgUnits, accessRoles }: TildelingToolbarProps) => {
     return (
-        <>
+        <VStack gap={'2'}>
             <HStack align={'end'} justify={'space-between'}>
-                <HStack align={'center'} gap={'2'}>
+                <VStack gap={'2'}>
+                    <Label>Filter på brukerens tilhørighet</Label>
                     <OrgUnitFilterModal orgUnitList={allOrgUnits} />
-                    <HelpText>
-                        Dette er kun filter for brukerens tilhørighet. Må ikke forveksles med
-                        org.enhetstildelingen.
-                    </HelpText>
-                </HStack>
+                </VStack>
                 <AllAccessRolesFilter roles={accessRoles} />
                 <ResourceModuleSearch />
             </HStack>
             <ChipsFilters />
-        </>
+        </VStack>
     );
 };
 

--- a/app/components/role/AssignResourceToRoleTable.tsx
+++ b/app/components/role/AssignResourceToRoleTable.tsx
@@ -13,7 +13,7 @@ interface AssignResourceToRoleTableProps {
     isAssignedResources: IResourceForList[];
     size: string;
     roleId: number;
-    totalPages: number;
+    totalPages?: number;
     currentPage: number;
     orgId: string;
     basePath?: string;

--- a/app/components/service-admin/ResourceDetailTable.tsx
+++ b/app/components/service-admin/ResourceDetailTable.tsx
@@ -2,25 +2,33 @@ import { Table } from '@navikt/ds-react';
 import React from 'react';
 import { IResource } from '~/data/types/resourceTypes';
 
-export const ResourceDetailTable = (props: { resource: IResource }) => {
+export const ResourceDetailTable = ({ resource }: { resource: IResource }) => {
     return (
         <>
             <Table>
                 <Table.Header>
                     <Table.Row>
-                        <Table.HeaderCell scope="col">Enhetsnavn</Table.HeaderCell>
-                        <Table.HeaderCell scope="col">Enhets Id</Table.HeaderCell>
-                        <Table.HeaderCell scope="col">Ressursgrense</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Navn</Table.HeaderCell>
+                        <Table.HeaderCell scope="col" align={'center'}>
+                            Ressursgrense
+                        </Table.HeaderCell>
+                        <Table.HeaderCell scope="col" align={'center'}>
+                            Tildelinger
+                        </Table.HeaderCell>
                     </Table.Row>
                 </Table.Header>
                 <Table.Body>
-                    {props.resource.validForOrgUnits.map((resourceItem, i) => (
+                    {resource.validForOrgUnits.map((resourceItem, i) => (
                         <Table.Row key={i}>
                             <Table.HeaderCell scope="row">
                                 {resourceItem.orgUnitName}
                             </Table.HeaderCell>
-                            <Table.DataCell>{resourceItem.orgUnitId}</Table.DataCell>
-                            <Table.DataCell>{resourceItem.resourceLimit}</Table.DataCell>
+                            <Table.DataCell align={'center'}>
+                                {resourceItem.resourceLimit}
+                            </Table.DataCell>
+                            <Table.DataCell align={'center'}>
+                                {resourceItem.assignedResources}
+                            </Table.DataCell>
                         </Table.Row>
                     ))}
                 </Table.Body>

--- a/app/components/user/AssignResourceToUserTable.tsx
+++ b/app/components/user/AssignResourceToUserTable.tsx
@@ -14,7 +14,7 @@ interface AssignResourceToUserTableProps {
     size: string;
     userId: string;
     orgId: string;
-    totalPages: number;
+    totalPages?: number;
     currentPage: number;
     basePath?: string;
 }

--- a/app/data/types/orgUnitTypes.tsx
+++ b/app/data/types/orgUnitTypes.tsx
@@ -11,7 +11,7 @@ export interface IUnitItem {
 
 export interface IUnitTree {
     totalItems: number;
-    totalPages: number | any;
+    totalPages?: number;
     currentPage: number;
     orgUnits: IUnitItem[];
 }

--- a/app/data/types/resourceTypes.ts
+++ b/app/data/types/resourceTypes.ts
@@ -64,14 +64,14 @@ export interface IResourceModuleOrgUnitDetail {
 
 export interface IAssignmentPage {
     totalItems: number;
-    totalPages?: number | any;
+    totalPages?: number;
     currentPage: number;
     resources: IResourceAssignment[];
 }
 
 export interface IAssignedResourcesList {
     totalItems: number;
-    totalPages: number | any;
+    totalPages?: number;
     currentPage: number;
     size: string;
     resources: IResourceAssignment[];
@@ -79,7 +79,7 @@ export interface IAssignedResourcesList {
 
 export interface IResourceList {
     totalItems: number;
-    totalPages?: number | string;
+    totalPages?: number;
     currentPage: number;
     resources: IResourceForList[];
 }
@@ -101,6 +101,7 @@ export interface IResourceItem {
     orgUnitId: string;
     orgUnitName: string;
     resourceLimit: number;
+    assignedResources?: number; // NEW
 }
 
 export interface IResourceAdminItem {
@@ -116,7 +117,7 @@ export interface IResourceAdminItem {
 
 export interface IResourceAdminList {
     totalItems: number;
-    totalPages?: number | string;
+    totalPages?: number;
     currentPage: number;
     resources: IResourceAdminItem[];
 }
@@ -124,25 +125,27 @@ export interface IResourceAdminList {
 export interface IResource {
     id: number;
     resourceId: string;
-    resourceRef: number;
-    identityProviderGroupName: string;
     resourceName: string;
     resourceType: string;
-    resourceLimit: number;
+    identityProviderGroupName: string;
     applicationAccessType: string;
     applicationAccessRole: string;
-    accessType: string;
-    applicationCategory: string[];
     platform: [];
+    accessType: string;
+    resourceLimit: number;
+    assignedResources?: number; // NEW
     resourceOwnerOrgUnitId: string;
     resourceOwnerOrgUnitName: string;
     validForOrgUnits: IResourceItem[];
     validForRoles: string[];
-    assigned?: boolean;
+    applicationCategory: string[];
     licenseEnforcement: string;
     hasCost: boolean;
     unitCost: number;
     status: string;
+    statusChanged?: string;
+    createdBy?: string;
+    dateCreated?: string;
 }
 
 // ----

--- a/app/data/types/userTypes.ts
+++ b/app/data/types/userTypes.ts
@@ -60,7 +60,7 @@ export interface IOrgUnitForScope {
 // -----------------------
 export interface IUserPage {
     totalItems: number;
-    totalPages?: number | any;
+    totalPages?: number;
     currentPage: number;
     size: string;
     users: IUserItem[];
@@ -101,14 +101,14 @@ export interface IRole {
 
 export interface IRoleList {
     totalItems: number;
-    totalPages: number | any;
+    totalPages?: number;
     currentPage: number;
     roles: IRole[];
 }
 
 export interface IMemberPage {
     totalItems: number;
-    totalPages: number | any;
+    totalPages?: number;
     currentPage: number;
     size: number;
     members: IMemberItem[];
@@ -125,7 +125,7 @@ export interface IMemberItem {
 // THIS
 export interface IAssignedUsers {
     totalItems: number;
-    totalPages?: number | any;
+    totalPages?: number;
     currentPage: number;
     size: string;
     users: IUser[];
@@ -133,7 +133,7 @@ export interface IAssignedUsers {
 
 export interface IAssignedRoles {
     totalItems: number;
-    totalPages: number | any;
+    totalPages?: number;
     currentPage: number;
     roles: IRole[];
 }

--- a/app/novari-theme.css
+++ b/app/novari-theme.css
@@ -26,6 +26,8 @@
     --a-surface-alt-3-subtle: #e5e4fa;
     --a-surface-alt-3-moderate: #6b133d;
 
+    --ac-table-row-selected: var(--a-surface-alt-3-subtle);
+
     .novari-header {
         background: #fcf5ed;
     }

--- a/app/routes/ressurs-admin._index.tsx
+++ b/app/routes/ressurs-admin._index.tsx
@@ -17,6 +17,7 @@ import AllAccessRolesFilter from '~/components/resource-module-admin/AllAccessRo
 import { IUnitItem } from '~/data/types/orgUnitTypes';
 import { IAccessRole } from '~/data/types/userTypes';
 import { ErrorMessage } from '~/components/common/ErrorMessage';
+import { SecondaryAddNewLinkButton } from '~/components/common/Buttons/SecondaryAddNewLinkButton';
 
 export function links() {
     return [{ rel: 'stylesheet', href: styles }];
@@ -64,17 +65,11 @@ export default function ResourceAdminIndex() {
                 FilterComponents={<AllAccessRolesFilter roles={roles} />}
                 SearchComponent={<ResourceModuleSearch />}
                 CreateNewButton={
-                    <Button
-                        role="link"
-                        as="a"
+                    <SecondaryAddNewLinkButton
                         id="create-assignment"
-                        className={'no-underline-button'}
-                        variant={'secondary'}
-                        iconPosition="right"
-                        icon={<PlusIcon aria-hidden />}
-                        onClick={() => navigate('opprett-ny-tildeling')}>
-                        Opprett ny tildeling
-                    </Button>
+                        label="Opprett ny tildeling"
+                        handleOnClick={() => navigate('opprett-ny-tildeling')}
+                    />
                 }
             />
             <ResourceModuleAdminUsersTable

--- a/app/routes/ressurs-admin.opprett-ny-tildeling.tsx
+++ b/app/routes/ressurs-admin.opprett-ny-tildeling.tsx
@@ -209,9 +209,6 @@ export default function ResourceModuleAdminTabTildel() {
             : '';
     };
 
-    const missingFields =
-        !newAssignment.user || newAssignment.orgUnits.length === 0 || !newAssignment.accessRoleId;
-
     return (
         <section className={'content tildeling-section-container'}>
             <VStack gap={'8'}>
@@ -311,11 +308,7 @@ export default function ResourceModuleAdminTabTildel() {
                 </ExpansionCard>
 
                 <div className={'tildeling-section'}>
-                    <SummaryOfTildeling
-                        assignment={newAssignment}
-                        missingFields={missingFields}
-                        accessRoles={accessRoles}
-                    />
+                    <SummaryOfTildeling assignment={newAssignment} accessRoles={accessRoles} />
                     <Form method={'post'} onSubmit={handleSubmit}>
                         <input type={'hidden'} name={'resourceId'} id={'resourceId'} />
                         <input type={'hidden'} name={'accessRoleId'} id={'accessRoleId'} />
@@ -326,7 +319,14 @@ export default function ResourceModuleAdminTabTildel() {
                             name={'includeSubOrgUnits'}
                             id={'includeSubOrgUnits'}
                         />
-                        <Button disabled={missingFields}>Lagre tildeling</Button>
+                        <Button
+                            disabled={
+                                !newAssignment.user ||
+                                newAssignment.orgUnits.length === 0 ||
+                                !newAssignment.accessRoleId
+                            }>
+                            Lagre tildeling
+                        </Button>
                     </Form>
                 </div>
             </VStack>

--- a/app/routes/ressurs-admin.opprett-ny-tildeling.tsx
+++ b/app/routes/ressurs-admin.opprett-ny-tildeling.tsx
@@ -1,4 +1,4 @@
-import { Button, ExpansionCard, Heading, Switch } from '@navikt/ds-react';
+import { Button, ExpansionCard, Heading, Switch, VStack } from '@navikt/ds-react';
 import {
     Form,
     useActionData,
@@ -34,6 +34,7 @@ import { IUnitItem, IUnitTree } from '~/data/types/orgUnitTypes';
 import { IAccessRole } from '~/data/types/userTypes';
 import { ErrorMessage } from '~/components/common/ErrorMessage';
 import { getErrorTextFromResponse } from '~/data/helpers';
+import { TableHeader } from '~/components/common/Table/Header/TableHeader';
 
 export function links() {
     return [{ rel: 'stylesheet', href: styles }];
@@ -212,104 +213,110 @@ export default function ResourceModuleAdminTabTildel() {
 
     return (
         <section className={'content tildeling-section-container'}>
-            <Heading className={'heading'} level={'2'} size={'large'}>
-                Tildel rettigheter
-            </Heading>
-            <ExpansionCard
-                size="small"
-                aria-label="Small-variant"
-                defaultOpen={true}
-                className={newAssignment.user ? 'expansion-green' : ''}>
-                <ExpansionCard.Header>
-                    {newAssignment.user ? (
-                        <ExpansionCard.Title>
-                            <CheckmarkCircleIcon /> Bruker valgt
-                        </ExpansionCard.Title>
-                    ) : (
-                        <ExpansionCard.Title>
-                            Finn brukeren å tildele rettigheter til
-                        </ExpansionCard.Title>
-                    )}
-                </ExpansionCard.Header>
-                <ExpansionCard.Content>
-                    <div className={'tildeling-section'}>
-                        <TildelingToolbar allOrgUnits={allOrgUnits} accessRoles={accessRoles} />
-                        <TildelUserSearchResultList
-                            newAssignment={newAssignment}
-                            usersPage={usersPage}
-                            handleSelectUser={handleSelectUser}
-                        />
-                    </div>
-                </ExpansionCard.Content>
-            </ExpansionCard>
+            <VStack gap={'8'}>
+                <TableHeader title="Tildel rettigheter" isSubHeader={true} />
+                <ExpansionCard
+                    size="small"
+                    aria-label="Small-variant"
+                    defaultOpen={true}
+                    className={newAssignment.user ? 'expansion-green' : ''}>
+                    <ExpansionCard.Header>
+                        {newAssignment.user ? (
+                            <ExpansionCard.Title>
+                                <CheckmarkCircleIcon /> Bruker valgt
+                            </ExpansionCard.Title>
+                        ) : (
+                            <ExpansionCard.Title>
+                                Finn brukeren å tildele rettigheter til
+                            </ExpansionCard.Title>
+                        )}
+                    </ExpansionCard.Header>
+                    <ExpansionCard.Content>
+                        <VStack>
+                            <TildelingToolbar allOrgUnits={allOrgUnits} accessRoles={accessRoles} />
+                            <TildelUserSearchResultList
+                                newAssignment={newAssignment}
+                                usersPage={usersPage}
+                                handleSelectUser={handleSelectUser}
+                            />
+                        </VStack>
+                    </ExpansionCard.Content>
+                </ExpansionCard>
 
-            <ExpansionCard
-                size="small"
-                aria-label="Small-variant"
-                className={newAssignment.accessRoleId ? 'expansion-green' : ''}>
-                <ExpansionCard.Header>
-                    {newAssignment.accessRoleId ? (
-                        <ExpansionCard.Title>
-                            <CheckmarkCircleIcon /> Rolle valgt
-                        </ExpansionCard.Title>
-                    ) : (
-                        <ExpansionCard.Title>Velg rolle</ExpansionCard.Title>
-                    )}
-                </ExpansionCard.Header>
-                <ExpansionCard.Content>
-                    <ChooseAccessRole
+                <ExpansionCard
+                    size="small"
+                    aria-label="Small-variant"
+                    className={newAssignment.accessRoleId ? 'expansion-green' : ''}>
+                    <ExpansionCard.Header>
+                        {newAssignment.accessRoleId ? (
+                            <ExpansionCard.Title>
+                                <CheckmarkCircleIcon /> Rolle valgt
+                            </ExpansionCard.Title>
+                        ) : (
+                            <ExpansionCard.Title>Velg rolle</ExpansionCard.Title>
+                        )}
+                    </ExpansionCard.Header>
+                    <ExpansionCard.Content>
+                        <ChooseAccessRole
+                            accessRoles={accessRoles}
+                            setNewAccessRole={setNewAccessRole}
+                        />
+                    </ExpansionCard.Content>
+                </ExpansionCard>
+
+                <ExpansionCard
+                    size="small"
+                    aria-label="Small-variant"
+                    className={newAssignment.orgUnits.length > 0 ? 'expansion-green' : ''}>
+                    <ExpansionCard.Header>
+                        {newAssignment.orgUnits.length > 0 ? (
+                            <ExpansionCard.Title>
+                                <CheckmarkCircleIcon /> Organisasjonsenheter valgt
+                            </ExpansionCard.Title>
+                        ) : (
+                            <ExpansionCard.Title>Legg til organisasjonsenheter</ExpansionCard.Title>
+                        )}
+                    </ExpansionCard.Header>
+                    <ExpansionCard.Content>
+                        <div className={'tildeling-section'}>
+                            <Switch
+                                onClick={() => handleChangeIncludeSubOrgUnits()}
+                                checked={includeSubOrgUnitsState}>
+                                Inkluder underliggende enheter
+                            </Switch>
+
+                            <OrgUnitTreeSelector
+                                orgUnitList={allOrgUnits}
+                                selectedOrgUnits={selectedOrgUnits}
+                                setSelectedOrgUnits={(newSelected) =>
+                                    setSelectedOrgUnits(newSelected)
+                                }
+                                includeSubOrgUnitsState={includeSubOrgUnitsState}
+                            />
+                        </div>
+                    </ExpansionCard.Content>
+                </ExpansionCard>
+
+                <div className={'tildeling-section'}>
+                    <SummaryOfTildeling
+                        assignment={newAssignment}
+                        missingFields={missingFields}
                         accessRoles={accessRoles}
-                        setNewAccessRole={setNewAccessRole}
                     />
-                </ExpansionCard.Content>
-            </ExpansionCard>
-
-            <ExpansionCard
-                size="small"
-                aria-label="Small-variant"
-                className={newAssignment.orgUnits.length > 0 ? 'expansion-green' : ''}>
-                <ExpansionCard.Header>
-                    {newAssignment.orgUnits.length > 0 ? (
-                        <ExpansionCard.Title>
-                            <CheckmarkCircleIcon /> Organisasjonsenheter valgt
-                        </ExpansionCard.Title>
-                    ) : (
-                        <ExpansionCard.Title>Legg til organisasjonsenheter</ExpansionCard.Title>
-                    )}
-                </ExpansionCard.Header>
-                <ExpansionCard.Content>
-                    <div className={'tildeling-section'}>
-                        <Switch
-                            onClick={() => handleChangeIncludeSubOrgUnits()}
-                            checked={includeSubOrgUnitsState}>
-                            Inkluder underliggende enheter
-                        </Switch>
-
-                        <OrgUnitTreeSelector
-                            orgUnitList={allOrgUnits}
-                            selectedOrgUnits={selectedOrgUnits}
-                            setSelectedOrgUnits={(newSelected) => setSelectedOrgUnits(newSelected)}
-                            includeSubOrgUnitsState={includeSubOrgUnitsState}
+                    <Form method={'post'} onSubmit={handleSubmit}>
+                        <input type={'hidden'} name={'resourceId'} id={'resourceId'} />
+                        <input type={'hidden'} name={'accessRoleId'} id={'accessRoleId'} />
+                        <input type={'hidden'} name={'scopeId'} id={'scopeId'} />
+                        <input type={'hidden'} name={'orgUnits'} id={'orgUnits'} />
+                        <input
+                            type={'hidden'}
+                            name={'includeSubOrgUnits'}
+                            id={'includeSubOrgUnits'}
                         />
-                    </div>
-                </ExpansionCard.Content>
-            </ExpansionCard>
-
-            <div className={'tildeling-section'}>
-                <SummaryOfTildeling
-                    assignment={newAssignment}
-                    missingFields={missingFields}
-                    accessRoles={accessRoles}
-                />
-                <Form method={'post'} onSubmit={handleSubmit}>
-                    <input type={'hidden'} name={'resourceId'} id={'resourceId'} />
-                    <input type={'hidden'} name={'accessRoleId'} id={'accessRoleId'} />
-                    <input type={'hidden'} name={'scopeId'} id={'scopeId'} />
-                    <input type={'hidden'} name={'orgUnits'} id={'orgUnits'} />
-                    <input type={'hidden'} name={'includeSubOrgUnits'} id={'includeSubOrgUnits'} />
-                    <Button disabled={missingFields}>Lagre tildeling</Button>
-                </Form>
-            </div>
+                        <Button disabled={missingFields}>Lagre tildeling</Button>
+                    </Form>
+                </div>
+            </VStack>
         </section>
     );
 }

--- a/app/routes/ressurs-admin.opprett-ny-tildeling.tsx
+++ b/app/routes/ressurs-admin.opprett-ny-tildeling.tsx
@@ -251,6 +251,7 @@ export default function ResourceModuleAdminTabTildel() {
                 <ExpansionCard
                     size="small"
                     aria-label="Small-variant"
+                    defaultOpen={true}
                     className={newAssignment.accessRoleId ? 'expansion-green' : ''}>
                     <ExpansionCard.Header>
                         {newAssignment.accessRoleId ? (
@@ -276,6 +277,7 @@ export default function ResourceModuleAdminTabTildel() {
                 <ExpansionCard
                     size="small"
                     aria-label="Small-variant"
+                    defaultOpen={true}
                     className={newAssignment.orgUnits.length > 0 ? 'expansion-green' : ''}>
                     <ExpansionCard.Header>
                         {newAssignment.orgUnits.length > 0 ? (

--- a/app/routes/ressurs-admin.opprett-ny-tildeling.tsx
+++ b/app/routes/ressurs-admin.opprett-ny-tildeling.tsx
@@ -1,4 +1,4 @@
-import { Button, ExpansionCard, Heading, HStack, Switch, VStack } from '@navikt/ds-react';
+import { Button, ExpansionCard, HStack, Switch, VStack } from '@navikt/ds-react';
 import {
     Form,
     useActionData,
@@ -9,11 +9,10 @@ import {
 } from '@remix-run/react';
 import { LoaderFunctionArgs } from '@remix-run/router';
 import { useEffect, useState } from 'react';
-import TildelingToolbar from '../components/resource-module-admin/opprettTildeling/TildelingToolbar';
 import { fetchAllOrgUnits } from '~/data/fetch-resources';
 import { fetchAccessRoles } from '~/data/kontrollAdmin/kontroll-admin-define-role';
 import { IResourceModuleAssignment, IResourceModuleUser } from '~/data/types/resourceTypes';
-import TildelUserSearchResultList from '../components/resource-module-admin/opprettTildeling/TildelUserSearchResultList';
+import TildelUsersTable from '../components/resource-module-admin/opprettTildeling/TildelUsersTable';
 import {
     fetchUsersWhoCanGetAssignments,
     postNewTildelingForUser,
@@ -237,12 +236,13 @@ export default function ResourceModuleAdminTabTildel() {
                     </ExpansionCard.Header>
                     <ExpansionCard.Content>
                         <VStack paddingBlock={'0 8'} paddingInline={'4'}>
-                            <TildelingToolbar allOrgUnits={allOrgUnits} accessRoles={accessRoles} />
-                            <TildelUserSearchResultList
+                            <TildelUsersTable
                                 newAssignment={newAssignment}
                                 usersPage={usersPage}
                                 handleSelectUser={handleSelectUser}
                                 size={size}
+                                allOrgUnits={allOrgUnits}
+                                accessRoles={accessRoles}
                             />
                         </VStack>
                     </ExpansionCard.Content>

--- a/app/routes/ressurser.$id.tsx
+++ b/app/routes/ressurser.$id.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import styles from '../components/resource/resource.css?url';
-import { Box, HStack, LinkPanel, Loader, Tabs, VStack } from '@navikt/ds-react';
+import { Box, Button, HStack, LinkPanel, Loader, Tabs, VStack } from '@navikt/ds-react';
 import {
     Link,
     Outlet,
@@ -17,11 +17,17 @@ import { BASE_PATH } from '../../environment';
 import { ResourceInfoBox } from '~/components/common/ResourceInfoBox';
 import { fetchUserTypes } from '~/data/fetch-kodeverk';
 import { TableHeader } from '~/components/common/Table/Header/TableHeader';
-import { PersonGroupIcon, PersonIcon } from '@navikt/aksel-icons';
+import { PersonGroupIcon, PersonIcon, PlusIcon } from '@navikt/aksel-icons';
 import { useLoadingState } from '~/components/common/customHooks';
-import { getResourceNewAssignmentUrl, RESOURCES } from '~/data/paths';
+import {
+    getResourceNewAssignmentUrl,
+    RESOURCES,
+    SERVICE_ADMIN_NEW_APPLICATION_RESOURCE_CREATE,
+} from '~/data/paths';
 import { IResource } from '~/data/types/resourceTypes';
 import { ErrorMessage } from '~/components/common/ErrorMessage';
+import { TableHeaderLayout } from '~/components/common/Table/Header/TableHeaderLayout';
+import { SecondaryAddNewLinkButton } from '~/components/common/Buttons/SecondaryAddNewLinkButton';
 
 export function links() {
     return [{ rel: 'stylesheet', href: styles }];
@@ -83,18 +89,24 @@ export default function ResourceById() {
     return (
         <section className={'content'}>
             <VStack gap="4">
-                <VStack gap="4">
-                    <ResourceInfoBox resource={resource} userTypeKodeverk={userTypeKodeverk} />
-                    <Box className={'filters'} paddingBlock={'8'}>
-                        <LinkPanel
-                            href={`${basePath}${getResourceNewAssignmentUrl(resource.id)}/${state === 'bruker-tildelinger' ? 'brukere' : 'grupper'}`}
-                            border>
-                            <LinkPanel.Title>Ny tildeling</LinkPanel.Title>
-                        </LinkPanel>
-                    </Box>
-                </VStack>
+                <ResourceInfoBox resource={resource} userTypeKodeverk={userTypeKodeverk} />
 
-                <TableHeader isSubHeader={true} title={'Tildelinger'} titleAlignment={'center'} />
+                <HStack paddingBlock={'8 0'}>
+                    <TableHeader
+                        isSubHeader={true}
+                        title={'Tildelinger'}
+                        HeaderButton={
+                            <SecondaryAddNewLinkButton
+                                label="Ny tildeling"
+                                handleOnClick={() =>
+                                    navigate(
+                                        `${getResourceNewAssignmentUrl(resource.id)}/${state === 'bruker-tildelinger' ? 'brukere' : 'grupper'}`
+                                    )
+                                }
+                            />
+                        }
+                    />
+                </HStack>
                 <Tabs value={state} onChange={handleChangeTab}>
                     <Tabs.List>
                         <Tabs.Tab

--- a/app/routes/tjeneste-admin.ressurs.$id.tsx
+++ b/app/routes/tjeneste-admin.ressurs.$id.tsx
@@ -22,6 +22,7 @@ import {
 } from '~/data/paths';
 import { IResource } from '~/data/types/resourceTypes';
 import { ErrorMessage } from '~/components/common/ErrorMessage';
+import { TableHeader } from '~/components/common/Table/Header/TableHeader';
 
 export function links() {
     return [{ rel: 'stylesheet', href: styles }];
@@ -102,9 +103,11 @@ export default function ResourceById() {
                 </VStack>
 
                 <VStack gap="4">
-                    <Heading level="2" size="large" align={'center'} spacing>
-                        Tilgjengelig for følgende organisasjonsenheter
-                    </Heading>
+                    <TableHeader
+                        isSubHeader={true}
+                        title={'Tilgjengelig for følgende organisasjonsenheter'}
+                        spacing={true}
+                    />
                     {source === 'gui' && (
                         <HStack justify={'end'} align={'end'}>
                             <Button

--- a/app/routes/tjeneste-admin.ressurser._index.tsx
+++ b/app/routes/tjeneste-admin.ressurser._index.tsx
@@ -15,6 +15,7 @@ import { fetchApplicationCategories, fetchResourceDataSource } from '~/data/fetc
 import { TableHeaderLayout } from '~/components/common/Table/Header/TableHeaderLayout';
 import { SERVICE_ADMIN_NEW_APPLICATION_RESOURCE_CREATE } from '~/data/paths';
 import { ErrorMessage } from '~/components/common/ErrorMessage';
+import { SecondaryAddNewLinkButton } from '~/components/common/Buttons/SecondaryAddNewLinkButton';
 
 export async function loader({ request }: LoaderFunctionArgs) {
     const url = new URL(request.url);
@@ -71,15 +72,12 @@ export default function ServiceAdminIndex() {
                 }
                 CreateNewButton={
                     source === 'gui' ? (
-                        <Button
-                            role="link"
-                            className={'no-underline-button'}
-                            variant={'secondary'}
-                            iconPosition="right"
-                            icon={<PlusIcon aria-hidden />}
-                            onClick={() => navigate(SERVICE_ADMIN_NEW_APPLICATION_RESOURCE_CREATE)}>
-                            Opprett ny ressurs
-                        </Button>
+                        <SecondaryAddNewLinkButton
+                            label="Opprett ny ressurs"
+                            handleOnClick={() =>
+                                navigate(SERVICE_ADMIN_NEW_APPLICATION_RESOURCE_CREATE)
+                            }
+                        />
                     ) : undefined
                 }
             />

--- a/cypress/e2e/brukere/user.cy.ts
+++ b/cypress/e2e/brukere/user.cy.ts
@@ -4,7 +4,7 @@ describe('Check the user detail page', () => {
     before('Set default size cookie', () => {
         cy.setCookie('size', '25');
         wait(1000);
-        cy.getCookie('size').then((cookie) => expect(cookie.value).to.be.equal('25'));
+        cy.getCookie('size').then((cookie) => expect(cookie?.value).to.be.equal('25'));
     });
 
     it("Navigate to Karen Berg's information page and click 'Se Info'", () => {

--- a/cypress/e2e/grupper/grupper.cy.ts
+++ b/cypress/e2e/grupper/grupper.cy.ts
@@ -4,7 +4,7 @@ describe('Check roles page with mock data', () => {
     before('Set default size cookie', () => {
         cy.setCookie('size', '25');
         wait(1000);
-        cy.getCookie('size').then((cookie) => expect(cookie.value).to.be.equal('25'));
+        cy.getCookie('size').then((cookie) => expect(cookie?.value).to.be.equal('25'));
     });
 
     it('Navigate to Grupper', () => {
@@ -18,7 +18,7 @@ describe('Check roles page with mock data', () => {
 
     it('Check table exists, cookie "size" is 25, has 11 rows, then change to 5 rows and confirm length', () => {
         cy.getCookie('size').then((cookie) => {
-            expect(cookie.value).to.equal('25');
+            expect(cookie?.value).to.equal('25');
         });
         cy.get('#role-table').should('be.visible').find('tbody tr').should('have.length', 11);
         cy.get('#select-number-of-rows').select('5');

--- a/cypress/e2e/menu/menuItems.cy.ts
+++ b/cypress/e2e/menu/menuItems.cy.ts
@@ -4,7 +4,7 @@ describe('Check menu items for', () => {
     it('Systemadministrator', () => {
         cy.setCookie('cypresstestuser', 'sa');
         wait(1000);
-        cy.getCookie('cypresstestuser').then((cookie) => expect(cookie.value).to.be.equal('sa'));
+        cy.getCookie('cypresstestuser').then((cookie) => expect(cookie?.value).to.be.equal('sa'));
 
         cy.goToHome();
         cy.wait(1000);
@@ -18,7 +18,7 @@ describe('Check menu items for', () => {
     it('Ressursadministrator', () => {
         cy.setCookie('cypresstestuser', 'ra');
         wait(1000);
-        cy.getCookie('cypresstestuser').then((cookie) => expect(cookie.value).to.be.equal('ra'));
+        cy.getCookie('cypresstestuser').then((cookie) => expect(cookie?.value).to.be.equal('ra'));
 
         cy.goToHome();
         cy.wait(1000);
@@ -33,7 +33,7 @@ describe('Check menu items for', () => {
     it('Tjenesteadministrator', () => {
         cy.setCookie('cypresstestuser', 'ta');
         wait(1000);
-        cy.getCookie('cypresstestuser').then((cookie) => expect(cookie.value).to.be.equal('ta'));
+        cy.getCookie('cypresstestuser').then((cookie) => expect(cookie?.value).to.be.equal('ta'));
 
         cy.goToHome();
         cy.wait(1000);
@@ -49,7 +49,7 @@ describe('Check menu items for', () => {
     it('Tildeler', () => {
         cy.setCookie('cypresstestuser', 'td');
         wait(1000);
-        cy.getCookie('cypresstestuser').then((cookie) => expect(cookie.value).to.be.equal('td'));
+        cy.getCookie('cypresstestuser').then((cookie) => expect(cookie?.value).to.be.equal('td'));
 
         cy.goToHome();
         cy.wait(1000);

--- a/cypress/e2e/ressurser/nyTildeling.cy.ts
+++ b/cypress/e2e/ressurser/nyTildeling.cy.ts
@@ -2,7 +2,7 @@ describe('See that assignment.resource.$id.user renders with users', () => {
     it('Navigate to "Ny Tildeling"', () => {
         cy.goToSpecificResource();
         cy.wait(1000);
-        cy.get('a').contains('Ny tildeling').click();
+        cy.get('Button').contains('Ny tildeling').click();
         cy.wait(1000);
         cy.url().should('include', '/brukere');
     });

--- a/cypress/e2e/ressurser/nyTildelingGruppe.cy.ts
+++ b/cypress/e2e/ressurser/nyTildelingGruppe.cy.ts
@@ -2,7 +2,7 @@ describe('See that assignment.resource.$id.group renders with groups', () => {
     it('Navigate to "Ny Tildeling"', () => {
         cy.goToSpecificResource();
         cy.wait(1000);
-        cy.get('a').contains('Ny tildeling').click();
+        cy.get('Button').contains('Ny tildeling').click();
         cy.wait(1000);
     });
 
@@ -36,7 +36,7 @@ describe('See that assignment.resource.$id.group renders with groups', () => {
         cy.wait(1000);
         cy.get('Button').contains('Grupper').should('exist').click();
         cy.wait(1000);
-        cy.get('a').contains('Ny tildeling').click();
+        cy.get('Button').contains('Ny tildeling').click();
         cy.wait(1000);
         cy.url().should('include', '/grupper');
         cy.get('Button')

--- a/cypress/mocks/handlers/resourceHandlers.ts
+++ b/cypress/mocks/handlers/resourceHandlers.ts
@@ -860,11 +860,11 @@ export const resourceHandlers = [
         'http://localhost:8061/beta/fintlabs-no/api/assignments/v2/resource/:id/users',
         ({ request, cookies }) => {
             // These queryParams will be used for later testing
-            const size = cookies.size ?? null;
-            const page = new URL(request.url).searchParams.get('page') ?? '0';
-            const search = new URL(request.url).searchParams.get('search') ?? '0';
-            const userType = new URL(request.url).searchParams.get('userType') ?? '0';
-            const orgUnits = new URL(request.url).searchParams.get('orgUnits').split(',') ?? [];
+            // const size = cookies.size ?? null;
+            // const page = new URL(request.url).searchParams.get('page') ?? '0';
+            // const search = new URL(request.url).searchParams.get('search') ?? '0';
+            // const userType = new URL(request.url).searchParams.get('userType') ?? '0';
+            // const orgUnits = new URL(request.url).searchParams.get('orgUnits').split(',') ?? [];
 
             return HttpResponse.json({
                 userList: {


### PR DESCRIPTION
- Rette opp i typefeil. `totalPages` fra alle apier har vært satt til `number | any`.. Den er nå satt til optional og kun `number`.
- Gjøre alle titler over tabeller til venstrestilt. Også subheadere under. bla.a. ressursinfo.-sidene.
- Endringer under "tildel rolle til bruker"-siden:
- - Bruke standard-header.
- - Fjernet en del spacing.
- - Lagt til paginering av brukere.
- - Endret listen til tabell for å lettere visualisere hvilken bruker man velger, samt å kunne bruke paginering for tabeller. Dette gjør også denne listen mer lik resten av systemet.
- - Fjerne andre valg når en bruker er valgt dår å lettere visualisere hvem som er valgt.
- - Gjøre hele raden klikkbar.
- - Gjøre det mulig å fjerne valgt bruker ved å klikke på enten raden eller knappen etter at den er valgt.
- - Forenkle tekst på labels i toolbaren.
- - Fjerne tooltip over org.enhetsfilter og erstatt det med en label.